### PR TITLE
Stop getOptionId matching numeric labels with existing option value id's

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php
@@ -89,7 +89,7 @@ abstract class AbstractSource implements
     public function getOptionId($value)
     {
         foreach ($this->getAllOptions() as $option) {
-            if ($this->mbStrcasecmp($option['label'], $value) == 0 || $option['value'] == $value) {
+            if ($this->mbStrcasecmp($option['label'], $value) == 0 || (int)$option['value'] === $value) {
                 return $option['value'];
             }
         }


### PR DESCRIPTION
Cast to int and strict type matching to keep existing functionality of returning an option id when an integer is passed of an existing option value for the attribute.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
An Update to PR 24935, which is not yet merged, but the underlying issue is still relevant.

When an attribute option has a numeric label, non type-strict comparison can cause mismatches in the getOptionId() function.
For example, if an option with option_id = 408 exists, and you try to create a new attribute option with label "408", `\Magento\Eav\Model\Entity\Attribute\OptionManagement` throws an inputException with the description 'Admin store attribute option label "408" is already exists'

### Related Pull Requestsz
<!-- related pull request placeholder -->
https://github.com/magento/magento2/pull/24935

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#24698

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Try to create a new attribute option where the label is the same as an existing option_id

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
